### PR TITLE
Disable proxy_buffer and increase client_max_body_size in nginx card

### DIFF
--- a/frontend/src/pages/help/websockets.vue
+++ b/frontend/src/pages/help/websockets.vue
@@ -47,13 +47,15 @@ ProxyRequests off
 http {
   server {
     server_mame example.com
-
+    client_max_body_size 500M;
+    
     location / {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $host;
 
       proxy_pass http://photoprism:2342;
 
+      proxy_buffering off;
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";


### PR DESCRIPTION
* This disables `proxy_buffering` (see: https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering) meaning the content is served as soon as nginx itself gets it (might also speedup things). This is especially good for larger files (like pictures)
* and sets the `client_max_body_size` (see: https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size) to 500M (even that might not be enough for uploading large videos, but the default is way to low to upload pictures via the UI  when using nginx.